### PR TITLE
Pin dependencies in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,20 @@ jobs:
       # This looks retarded but it's correct
       # see https://github.com/rust-lang/rustup/issues/2070#issuecomment-545096849
       run: rustup show
+    - name: Pin thiserror
+      run: cargo update -p thiserror --precise 1.0.25
+    - name: Pin serde
+      run: cargo update -p serde --precise 1.0.126
+    - name: Pin serde_derive
+      run: cargo update -p serde_derive --precise 1.0.136
+    - name: Pin quote
+      run: cargo update -p quote --precise 1.0.9
+    - name: Pin syn
+      run: cargo update -p syn --precise 1.0.72
+    - name: Pin proc-macro2
+      run: cargo update -p proc-macro2 --precise 1.0.27
+    - name: Pin unicode-segmentation
+      run: cargo update -p unicode-segmentation --precise 1.7.1
     - name: Build
       run: cargo build --verbose
     - name: Run unit tests


### PR DESCRIPTION
A MSRV CI check was using latest dependencies which broke when they updated MSRV. This pins them to prevent build failures.